### PR TITLE
Support images in markdown documentation

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -130,7 +130,14 @@ const plugins = [
   {
     resolve: "gatsby-transformer-remark",
     options: {
-      plugins: [],
+      plugins: [
+        {
+          resolve: `gatsby-remark-images`,
+          options: {
+            maxWidth: 800,
+          },
+        },
+      ],
     },
   },
 ]

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -134,7 +134,7 @@ const plugins = [
         {
           resolve: `gatsby-remark-images`,
           options: {
-            maxWidth: 800,
+            maxWidth: 802,
           },
         },
       ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -134,7 +134,7 @@ const plugins = [
         {
           resolve: `gatsby-remark-images`,
           options: {
-            maxWidth: 801,
+            maxWidth: 800,
           },
         },
       ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -134,7 +134,7 @@ const plugins = [
         {
           resolve: `gatsby-remark-images`,
           options: {
-            maxWidth: 800,
+            maxWidth: 801,
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-sharp": "^3.1.2",
     "gatsby-plugin-sitemap": "^2.6.0",
+    "gatsby-remark-images": "^4.2.0",
     "gatsby-source-filesystem": "^2.6.1",
     "gatsby-source-wordpress-experimental": "6.0.0",
     "gatsby-transformer-remark": "^3.2.0",

--- a/src/components/parse-html.js
+++ b/src/components/parse-html.js
@@ -27,7 +27,7 @@ export const getStyleObjectFromString = (styles) => {
     if (!property) return
 
     const formattedProperty = formatStringToCamelCase(property.trim())
-    style[formattedProperty] = value.trim()
+    style[formattedProperty] = value ? value.trim() : null
   })
 
   return style


### PR DESCRIPTION
Enable gatsby-remark-images plugin to support markdown syntax for images.

`![Image alt text](./path-to-image.png)`

For reference, see https://www.gatsbyjs.com/plugins/gatsby-remark-images/?=gatsby-remark-images and https://www.gatsbyjs.com/docs/working-with-images-in-markdown/

Part of https://github.com/wp-graphql/wpgraphql.com/issues/20