### PR TITLE
Docs/read plugin markdown

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -116,15 +116,16 @@ const plugins = [
     resolve: "gatsby-plugin-git-clone",
     options: {
       repository: "https://github.com/markkelnar/wp-graphql.git",
-      path: `${__dirname}/documentation/wp-graphql/main`,
+      path: `${__dirname}/documentation/wp-graphql/v1`,
       branch: "docs/add-faqs",
     },
   },
+  "gatsby-transformer-yaml",
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: `${__dirname}/documentation/wp-graphql/main/docs`,
-      name: "documentation-main",
+      path: `${__dirname}/documentation/wp-graphql/v1/docs`,
+      name: "documentation-v1",
     },
   },
   {
@@ -134,7 +135,7 @@ const plugins = [
         {
           resolve: `gatsby-remark-images`,
           options: {
-            maxWidth: 802,
+            maxWidth: 800,
           },
         },
       ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -133,9 +133,9 @@ const plugins = [
     options: {
       plugins: [
         {
-          resolve: `gatsby-remark-images`,
+          resolve: `gatsby-remark-copy-linked-files`,
           options: {
-            maxWidth: 800,
+            ignoreFileExtensions: [],
           },
         },
       ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,7 +32,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         }
       }
       markdownDocs: allMarkdownRemark(
-        filter: { fileAbsolutePath: { regex: "//v1/docs//" } }
+        filter: { fileAbsolutePath: { regex: "/\/v1\/docs\//" } }
       ) {
         nodes {
           __typename

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,9 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           }
         }
       }
-      markdownDocs: allMarkdownRemark {
+      markdownDocs: allMarkdownRemark(
+        filter: { fileAbsolutePath: { regex: "//v1/docs//" } }
+      ) {
         nodes {
           __typename
           id

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gatsby-source-wordpress-experimental": "6.0.0",
     "gatsby-transformer-remark": "^3.2.0",
     "gatsby-transformer-sharp": "^3.1.0",
+    "gatsby-transformer-yaml": "^3.3.0",
     "is-url-external": "^1.0.3",
     "lint-staged": ">=10.5.2",
     "prism-react-renderer": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gatsby-plugin-react-svg": "^3.0.0",
     "gatsby-plugin-sharp": "^3.1.2",
     "gatsby-plugin-sitemap": "^2.6.0",
-    "gatsby-remark-images": "^4.2.0",
+    "gatsby-remark-copy-linked-files": "^4.1.0",
     "gatsby-source-filesystem": "^2.6.1",
     "gatsby-source-wordpress-experimental": "6.0.0",
     "gatsby-transformer-remark": "^3.2.0",

--- a/src/components/DocsSidebar.js
+++ b/src/components/DocsSidebar.js
@@ -13,7 +13,7 @@ const DocsSidebar = ({ title }) => {
             name
             items {
               uri
-              label
+              title: label
             }
           }
         }
@@ -37,14 +37,10 @@ const DocsSidebar = ({ title }) => {
     }
   `)
 
-  // Make a list of document titles from the document sources if label/title is not found in the yaml.
-  let otherTitles = data.markdownDocs.nodes
-    .map(function (elem) {
-      return elem.frontmatter
-    })
-    .concat(data.wpDocs.nodes)
-
-  const navRoutes = navMenuListFromYaml(data.navMenu.nodes, otherTitles)
+  const navRoutes = navMenuListFromYaml(
+    data.navMenu.nodes,
+    data.markdownDocs.nodes.concat(data.wpDocs.nodes)
+  )
 
   const routes = flatListToHierarchical(navRoutes, {
     idKey: "id",

--- a/src/templates/WpDocument.js
+++ b/src/templates/WpDocument.js
@@ -8,16 +8,16 @@ import DocsSidebar from "../components/DocsSidebar"
 import { ParseHtml } from "../components/parse-html"
 import TableOfContents from "../components/TableOfContents"
 import Breadcrumb from "../components/breadcrumb/Breadcrumb"
-import {getPagination} from "../utils";
-import Pagination from "../components/Pagination";
+import { getPagination } from "../utils"
+import Pagination from "../components/Pagination"
 
 const WpContentNode = ({ data }) => {
   const {
     wpContentNode: { title, content, uri },
-      allWpDocument
+    allWpDocument,
   } = data
 
-    const pagination = getPagination(uri, allWpDocument.nodes)
+  const pagination = getPagination(uri, allWpDocument.nodes)
 
   const crumbs = [
     {
@@ -54,11 +54,11 @@ const WpContentNode = ({ data }) => {
                       {title}
                     </Heading>
                     {ParseHtml(content)}
-                      <Pagination
-                          sx={{ ".pagination-link": { wordBreak: "break-word" } }}
-                          next={pagination.next}
-                          previous={pagination.previous}
-                      />
+                    <Pagination
+                      sx={{ ".pagination-link": { wordBreak: "break-word" } }}
+                      next={pagination.next}
+                      previous={pagination.previous}
+                    />
                   </Box>
                   <TableOfContents
                     content={content}

--- a/src/templates/WpDocument.js
+++ b/src/templates/WpDocument.js
@@ -8,16 +8,30 @@ import DocsSidebar from "../components/DocsSidebar"
 import { ParseHtml } from "../components/parse-html"
 import TableOfContents from "../components/TableOfContents"
 import Breadcrumb from "../components/breadcrumb/Breadcrumb"
-import { getPagination } from "../utils"
+import { getPagination, navMenuListFromYaml } from "../utils"
 import Pagination from "../components/Pagination"
 
 const WpContentNode = ({ data }) => {
   const {
     wpContentNode: { title, content, uri },
-    allWpDocument,
+    navMenu,
+    markdownDocs,
+    wpDocs,
   } = data
 
-  const pagination = getPagination(uri, allWpDocument.nodes)
+  // Get only the page items from navigation yaml in order
+  let navRoutes = navMenuListFromYaml(
+    navMenu.nodes,
+    markdownDocs.nodes.concat(wpDocs.nodes)
+  )
+  navRoutes = navRoutes
+    .map(function (item) {
+      item.uri = item.path
+      return item
+    })
+    .filter((item) => "#" !== item.path)
+
+  const pagination = getPagination(uri, navRoutes)
 
   const crumbs = [
     {
@@ -87,9 +101,30 @@ export const query = graphql`
         content
       }
     }
-    allWpDocument(sort: { fields: menuOrder }) {
+    navMenu: allDocsNavMenuYaml {
       nodes {
         id
+        section {
+          name
+          items {
+            uri
+            title: label
+          }
+        }
+      }
+    }
+    markdownDocs: allMarkdownRemark(
+      filter: { fileAbsolutePath: { regex: "//v1/docs//" } }
+    ) {
+      nodes {
+        frontmatter {
+          uri
+          title
+        }
+      }
+    }
+    wpDocs: allWpDocument {
+      nodes {
         uri
         title
       }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,6 +17,38 @@ exports.flatListToHierarchical = (
   return tree
 }
 
+// Create a list of doc nodes from the yaml file that fit the existing sidebarnav components.
+exports.navMenuListFromYaml = (nodes, titles) => {
+  let newNav = []
+  nodes.forEach((node) => {
+    // Section/parents with children items
+    let newItem = {
+      id: node.id,
+      title: node.section.name,
+      path: "#",
+      parent: null,
+      target: null,
+    }
+    newNav.push(newItem)
+    node.section.items.forEach((item) => {
+      // If yaml item doesn't have title, look for same document from other title sources
+      if (null === item.label) {
+        let found_item = titles.find((elem) => elem.uri === item.uri)
+        item.label = found_item ? found_item.title : null
+      }
+      let newItem = {
+        id: null,
+        title: item.label,
+        path: item.uri,
+        parent: node.id,
+        target: null,
+      }
+      newNav.push(newItem)
+    })
+  })
+  return newNav
+}
+
 exports.ensureTrailingSlash = (str) => (str.endsWith("/") ? str : `${str}/`)
 
 exports.getPagination = (uri, nodes) => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,7 +18,15 @@ exports.flatListToHierarchical = (
 }
 
 // Create a list of doc nodes from the yaml file that fit the existing sidebarnav components.
+// titles are a list of document titles from the document sources if label/title is not found in the yaml.
 exports.navMenuListFromYaml = (nodes, titles) => {
+  // flatten the titles list if any items contain frontmatter
+  titles = titles.map(function (elem) {
+    if (elem.frontmatter) {
+      return elem.frontmatter
+    }
+    return elem
+  })
   let newNav = []
   nodes.forEach((node) => {
     // Section/parents with children items
@@ -32,13 +40,13 @@ exports.navMenuListFromYaml = (nodes, titles) => {
     newNav.push(newItem)
     node.section.items.forEach((item) => {
       // If yaml item doesn't have title, look for same document from other title sources
-      if (null === item.label) {
+      if (null === item.title) {
         let found_item = titles.find((elem) => elem.uri === item.uri)
-        item.label = found_item ? found_item.title : null
+        item.title = found_item ? found_item.title : null
       }
       let newItem = {
         id: null,
-        title: item.label,
+        title: item.title,
         path: item.uri,
         parent: node.id,
         target: null,


### PR DESCRIPTION
When moving documentation for wp-graphql plugin to markdown in that repo, sidebar navigation in .com is building the sidebar navigation from wp docs. This includes the documents listed, the sections, order and pagination. Moving that info to a yaml file in wp-graphql with the markdown files.  The code here reads that file and uses document lists and order from the yaml. If a label/title is not in the yaml for a document, it will look for that title from the markdown file, then the existing wp content.

Can preview this branch running at the site https://wpgraphqldocs.gatsbyjs.io/