### PR TITLE
Add pedantic for remark doc parser

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -139,6 +139,7 @@ const plugins = [
           },
         },
       ],
+      pedantic: false,
     },
   },
 ]


### PR DESCRIPTION
Make use of the pedantic flag which changes how underscores are parsed by the remark library.

Resolves https://github.com/wp-graphql/wpgraphql.com/issues/22

