### PR TITLE
fix image hydration by rendering script tags

### DIFF
--- a/src/components/parse-html.js
+++ b/src/components/parse-html.js
@@ -39,7 +39,7 @@ export const ParseHtmlToReact = (html, components, reduceHeadings = false) => {
   }
 
   const transform = (node, i = 0) => {
-    if (node.type !== "tag") {
+    if (node.type !== "tag" && node.type !== `script`) {
       return
     }
 

--- a/src/components/parsed-components/index.js
+++ b/src/components/parsed-components/index.js
@@ -132,6 +132,8 @@ export const Noscript = (props) => {
   return <noscript {...props} />
 }
 
+export const Script = (props) => <script {...props} />
+
 const getId = (string) => {
   const regex = /status\/(\d+)/g
   let m


### PR DESCRIPTION
On the latest `gatsby-source-wordpress` script tags are used to store image hydration data. The implementation of react-html-parser here was stripping out script tags which broke image hydration.