### PR TITLE
fix: make sure script tags - children are not escaped

### DIFF
--- a/src/components/parsed-components/index.js
+++ b/src/components/parsed-components/index.js
@@ -132,7 +132,12 @@ export const Noscript = (props) => {
   return <noscript {...props} />
 }
 
-export const Script = (props) => <script {...props} />
+export const Script = ({ children, ...rest }) => (
+  <script
+    dangerouslySetInnerHTML={{ __html: children ? children.join("") : "" }}
+    {...rest}
+  />
+)
 
 const getId = (string) => {
   const regex = /status\/(\d+)/g


### PR DESCRIPTION
On some pages images are not getting loaded, that's because there is script snippet on the page that does hydration without React. Making sure images are loaded as fast as possible. The site is using some components parser to generate React components from data we have to make sure script tags are not sanitized by React.

In the snippet below you see that quotes here are actually sanitized:
![image](https://user-images.githubusercontent.com/1120926/145089503-6fc9bce5-8733-429f-a538-eaf2df09cad0.png)

If we use dangerouslyInnerHtml the script will be kept as such.
