### PR TITLE
refactor: create a redirect for the discord link from /discord and use on site

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1,1 +1,7 @@
-[]
+[
+  {
+    "source": "/discord",
+    "destination": "https://discord.gg/AGVBqqyaUY",
+    "permanent": true
+  }
+]

--- a/src/data/social.js
+++ b/src/data/social.js
@@ -35,7 +35,7 @@ export const socialFooterLinks = [
   },
   {
     name: "Discord",
-    href: "https://discord.gg/AGVBqqyaUY",
+    href: "/discord",
     icon: SiDiscord,
   },
 ]

--- a/src/pages/acf.js
+++ b/src/pages/acf.js
@@ -241,7 +241,7 @@ function Pricing() {
         handled through <a href="https://github.com/wp-graphql/wp-graphql-acf/issues" rel="noreferrer"
                            target="_blank">issues</a>. For general questions about the plugin,
         visit the <a
-        href="https://discord.gg/AGVBqqyaUY">WPGraphQL
+        href="/discord">WPGraphQL
         Discord</a>.
       </p>
     </div>

--- a/src/pages/acf.js
+++ b/src/pages/acf.js
@@ -5,6 +5,7 @@ import SiteLayout from "../components/Site/SiteLayout";
 import Image from 'next/image'
 import {Disclosure} from "@headlessui/react";
 import {ChevronUpIcon} from "@heroicons/react/20/solid";
+import Link from "next/link";
 
 const GET_NAV_MENU = gql`
 query GetNavMenu {
@@ -240,9 +241,9 @@ function Pricing() {
         feature requests are
         handled through <a href="https://github.com/wp-graphql/wp-graphql-acf/issues" rel="noreferrer"
                            target="_blank">issues</a>. For general questions about the plugin,
-        visit the <a
+        visit the <Link
         href="/discord">WPGraphQL
-        Discord</a>.
+        Discord</Link>.
       </p>
     </div>
   )

--- a/src/pages/community.js
+++ b/src/pages/community.js
@@ -23,7 +23,7 @@ function Community() {
     {
       name: "Discord",
       description: "The WPGraphQL Discord is a great place to communicate in real-time. Ask questions, discuss features, get to know other folks using WPGraphQL.",
-      link: "https://discord.gg/AGVBqqyaUY",
+      link: "/discord",
       icon: FaDiscord,
     },
     {


### PR DESCRIPTION
To simplify sharing and updating te link in the future if needed I've created a `/discord` path on the site that redirects to the invite link. This will make it much easire to point folks to the discord from memory instead of having to grab a link every time. 

While i was here I updated existing discord links on the site to use this new redirect so if we ever have to swap the link in the future it's only in the `redirects.json` file. 
